### PR TITLE
ENH, RF: config module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+2018-08-02
+----------
+* Add `config` module to `pyqmix.__all__`
+
 2018-08-01
 ----------
 * Support latest Qmix SDK

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 2018-08-02
 ----------
 * Add `config` module to `pyqmix.__all__`
+* Remove Qmix SDK header directory config option
 
 2018-08-01
 ----------

--- a/pyqmix/__init__.py
+++ b/pyqmix/__init__.py
@@ -10,9 +10,11 @@ from .bus import QmixBus
 from .pump import QmixPump
 from .valve import QmixValve, QmixExternalValve
 from .dio import QmixDigitalIO
+from . import config
 
 
-__all__ = [QmixBus, QmixPump, QmixValve, QmixExternalValve, QmixDigitalIO]
+__all__ = [QmixBus, QmixPump, QmixValve, QmixExternalValve, QmixDigitalIO,
+           config]
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/pyqmix/config.py
+++ b/pyqmix/config.py
@@ -42,7 +42,6 @@ def read_config():
                 raise
 
         cfg = OrderedDict([('qmix_dll_dir', ''),
-                           ('qmix_header_dir', ''),
                            ('qmix_config_dir', ''),
                            ('pumps', OrderedDict())])
 
@@ -93,25 +92,6 @@ def set_qmix_dll_dir(d):
     """
     cfg = read_config()
     cfg['qmix_dll_dir'] = d
-
-    with open(PYQMIX_CONFIG_FILE, 'w') as f:
-        yaml.dump(cfg, f)
-
-
-def set_qmix_header_dir(d):
-    """
-    Specify the location of the directory containing the Qmix SDK header (.h)
-    files.
-
-    Parameters
-    ----------
-    d : string
-        Th Qmix SDK header directory. Must be an absolute path. The directory
-        is typically called `include`.
-
-    """
-    cfg = read_config()
-    cfg['qmix_header_dir'] = d
 
     with open(PYQMIX_CONFIG_FILE, 'w') as f:
         yaml.dump(cfg, f)


### PR DESCRIPTION
- ENH: Add `config` module to `pyqmix.__all__`
- RF: Remove Qmix SDK header directory config option
