### PR TITLE
Multiple improvements to pump/valve handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
   `switch_valve_when_done` to match `wait_until_done` wording
 * Add `switch_valve_when_finished` keyword argument to
   `QmixPump.aspirate()` method
+* Wait until the pumps have actually started operating before checking
+  whether pumping has finished when using the `wait_until_done` kwarg.
 
 2018-09-13
 ----------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   `QmixPump.aspirate()` method
 * Wait until the pumps have actually started operating before checking
   whether pumping has finished when using the `wait_until_done` kwarg.
+* Imply `wait_until_done=True` when `switch_valve_when_done=True`
+  keyword argument is specified.
 
 2018-09-13
 ----------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+2018-10-04
+----------
+* Rename `switch_valve_when_finished` keyword argument to 
+  `switch_valve_when_done` to match `wait_until_done` wording
+
 2018-09-13
 ----------
 * Rename `blocking_wait` keyword argument to `wait_until_done`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 ----------
 * Rename `switch_valve_when_finished` keyword argument to 
   `switch_valve_when_done` to match `wait_until_done` wording
+* Add `switch_valve_when_finished` keyword argument to
+  `QmixPump.aspirate()` method
 
 2018-09-13
 ----------

--- a/pyqmix/pump.py
+++ b/pyqmix/pump.py
@@ -581,6 +581,11 @@ class QmixPump(object):
         self.valve.switch_position(self.valve.aspirate_pos)
         self._call('LCP_Aspirate', self._handle[0], volume, flow_rate)
         if wait_until_done:
+            # Wait until pumping has actually started.
+            while not self.is_pumping:
+                time.sleep(0.0005)
+
+            # Now wait until the pumping has finished.
             while self.is_pumping:
                 time.sleep(0.0005)
 
@@ -635,6 +640,11 @@ class QmixPump(object):
         self.valve.switch_position(self.valve.dispense_pos)
         self._call('LCP_Dispense', self._handle[0], volume, flow_rate)
         if wait_until_done:
+            # Wait until pumping has actually started.
+            while not self.is_pumping:
+                time.sleep(0.0005)
+
+            # Now wait until the pumping has finished.
             while self.is_pumping:
                 time.sleep(0.0005)
 
@@ -683,6 +693,11 @@ class QmixPump(object):
         self._call('LCP_SetFillLevel', self._handle[0], level, flow_rate)
 
         if wait_until_done:
+            # Wait until pumping has actually started.
+            while not self.is_pumping:
+                time.sleep(0.0005)
+
+            # Now wait until the pumping has finished.
             while self.is_pumping:
                 time.sleep(0.0005)
 
@@ -716,6 +731,11 @@ class QmixPump(object):
             self.valve.switch_position(self.valve.aspirate_pos)
         self._call('LCP_GenerateFlow', self._handle[0], flow_rate)
         if wait_until_done:
+            # Wait until pumping has actually started.
+            while not self.is_pumping:
+                time.sleep(0.0005)
+
+            # Now wait until the pumping has finished.
             while self.is_pumping:
                 time.sleep(0.0005)
 

--- a/pyqmix/pump.py
+++ b/pyqmix/pump.py
@@ -579,7 +579,7 @@ class QmixPump(object):
                 time.sleep(0.0005)
 
     def dispense(self, volume, flow_rate, wait_until_done=False,
-                 switch_valve_when_finished=False):
+                 switch_valve_when_done=False):
         """
         Dispense a certain volume with a certain flow rate.
 
@@ -597,9 +597,10 @@ class QmixPump(object):
         wait_until_done : bool
             Whether to halt program execution until done.
 
-        switch_valve_when_finished : bool
-            If set to ``True``, it switches valve to postion 1 when dispense is
-            finished. It only has effect if ``wait_until_done=True``.
+        switch_valve_when_done : bool
+            If set to ``True``, it switches valve to aspirate position after
+            the dispense is finished. It only takes effect if
+            ``wait_until_done=True``.
 
         Raises
         ------
@@ -628,7 +629,7 @@ class QmixPump(object):
             while self.is_pumping:
                 time.sleep(0.0005)
 
-            if switch_valve_when_finished:
+            if switch_valve_when_done:
                 self.valve.switch_position(self.valve.aspirate_pos)
 
     def set_fill_level(self, level, flow_rate, wait_until_done=False):

--- a/pyqmix/pump.py
+++ b/pyqmix/pump.py
@@ -554,8 +554,7 @@ class QmixPump(object):
 
         switch_valve_when_done : bool
             If set to ``True``, it switches valve to dispense position after
-            the aspiration is finished. It only takes effect if
-            ``wait_until_done=True``.
+            the aspiration is finished. Implies `wait_until_done=True`.
 
         Raises
         ------
@@ -577,6 +576,9 @@ class QmixPump(object):
         if self.fill_level + volume > self.volume_max:
             msg = 'Aspiration would exceed syringe volume.'
             raise ValueError(msg)
+
+        if switch_valve_when_done:
+            wait_until_done = True
 
         self.valve.switch_position(self.valve.aspirate_pos)
         self._call('LCP_Aspirate', self._handle[0], volume, flow_rate)
@@ -613,8 +615,7 @@ class QmixPump(object):
 
         switch_valve_when_done : bool
             If set to ``True``, it switches valve to aspirate position after
-            the dispense is finished. It only takes effect if
-            ``wait_until_done=True``.
+            the dispense is finished. Implies `wait_until_done=True`.
 
         Raises
         ------
@@ -636,6 +637,9 @@ class QmixPump(object):
         if self.fill_level < volume:
             msg = 'Current syringe fill level is insufficient.'
             raise ValueError(msg)
+
+        if switch_valve_when_done:
+            wait_until_done = True
 
         self.valve.switch_position(self.valve.dispense_pos)
         self._call('LCP_Dispense', self._handle[0], volume, flow_rate)

--- a/pyqmix/pump.py
+++ b/pyqmix/pump.py
@@ -535,7 +535,8 @@ class QmixPump(object):
         self._call('LCP_GetFlowRateMax', self._handle[0], self._flow_rate_max)
         return self._flow_rate_max[0]
 
-    def aspirate(self, volume, flow_rate, wait_until_done=False):
+    def aspirate(self, volume, flow_rate, wait_until_done=False,
+                 switch_valve_when_done=False):
         """
         Aspirate a certain volume with the specified flow rate.
 
@@ -550,6 +551,11 @@ class QmixPump(object):
 
         wait_until_done : bool
             Whether to block until done.
+
+        switch_valve_when_done : bool
+            If set to ``True``, it switches valve to dispense position after
+            the aspiration is finished. It only takes effect if
+            ``wait_until_done=True``.
 
         Raises
         ------
@@ -577,6 +583,9 @@ class QmixPump(object):
         if wait_until_done:
             while self.is_pumping:
                 time.sleep(0.0005)
+
+            if switch_valve_when_done:
+                self.valve.switch_position(self.valve.dispense_pos)
 
     def dispense(self, volume, flow_rate, wait_until_done=False,
                  switch_valve_when_done=False):


### PR DESCRIPTION
- RF: Rename `switch_valve_when_finished` to `switch_valve_when_done` 
- ENH: `QmixPump.aspirate()` now has `switch_valve_when_finished` kwarg
- BF/ENH: Wait for pumps to start before checking whether they're finished
- ENH: Imply `wait_until_done=True` if `switch_valve_when_done=True`