### PR TITLE
ENH: Improve DLL discovery

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
   whether pumping has finished when using the `wait_until_done` kwarg.
 * Imply `wait_until_done=True` when `switch_valve_when_done=True`
   keyword argument is specified.
+* Improve auto-discovery of Qmix SDK DLLs
 
 2018-09-13
 ----------

--- a/pyqmix/dio.py
+++ b/pyqmix/dio.py
@@ -10,7 +10,7 @@ if sys.version_info[0] < 3:
     from builtins import bytes
 
 from . import config
-from .tools import CHK
+from .tools import CHK, find_dll
 from .headers import DIGITAL_IO_HEADER
 
 
@@ -39,15 +39,18 @@ class QmixDigitalIO(object):
             self.name = name
 
         dll_dir = config.read_config().get('qmix_dll_dir', None)
-        if dll_dir is None:
-            self.dll_file = 'labbCAN_DigIO_API.dll'
+        dll_filename = 'labbCAN_DigIO_API.dll'
+
+        dll_path = find_dll(dll_dir=dll_dir, dll_filename=dll_filename)
+        if dll_path is None:
+            msg = 'Could not find the Qmix SDK DLL %s.' % dll_filename
+            raise RuntimeError(msg)
         else:
-            self.dll_file = os.path.join(dll_dir, 'labbCAN_DigIO_API.dll')
+            self.dll_path = dll_path
 
         self._ffi = FFI()
         self._ffi.cdef(DIGITAL_IO_HEADER)
-
-        self._dll = self._ffi.dlopen(self.dll_file)
+        self._dll = self._ffi.dlopen(self.dll_path)
 
         self._handle = self._ffi.new('dev_hdl *', 0)
 

--- a/pyqmix/error.py
+++ b/pyqmix/error.py
@@ -5,6 +5,7 @@ import os
 from cffi import FFI
 
 from . import config
+from .tools import find_dll
 from .headers import ERROR_HEADER
 
 
@@ -15,15 +16,18 @@ class QmixError(object):
     """
     def __init__(self, error_number):
         dll_dir = config.read_config().get('qmix_dll_dir', None)
-        if dll_dir is None:
-            self.dll_file = 'usl.dll'
+        dll_filename = 'usl.dll'
+
+        dll_path = find_dll(dll_dir=dll_dir, dll_filename=dll_filename)
+        if dll_path is None:
+            msg = 'Could not find the Qmix SDK DLL %s.' % dll_filename
+            raise RuntimeError(msg)
         else:
-            self.dll_file = os.path.join(dll_dir, 'usl.dll')
+            self.dll_path = dll_path
 
         self._ffi = FFI()
         self._ffi.cdef(ERROR_HEADER)
-
-        self._dll = self._ffi.dlopen(self.dll_file)
+        self._dll = self._ffi.dlopen(self.dll_path)
 
         self.error_number = error_number
         self._error_code = self._ffi.new('TErrCode *')

--- a/pyqmix/pump.py
+++ b/pyqmix/pump.py
@@ -14,7 +14,7 @@ if sys.version_info[0] < 3:
 
 from . import config
 from .valve import QmixValve
-from .tools import CHK
+from .tools import CHK, find_dll
 from .headers import PUMP_HEADER
 
 syringes = {'25 mL glass': dict(inner_diameter_mm=23.03294,
@@ -50,14 +50,18 @@ class QmixPump(object):
         """
         cfg = config.read_config()
         dll_dir = cfg.get('qmix_dll_dir', None)
-        if dll_dir is None:
-            self.dll_file = 'labbCAN_Pump_API.dll'
+        dll_filename = 'labbCAN_Pump_API.dll'
+
+        dll_path = find_dll(dll_dir=dll_dir, dll_filename=dll_filename)
+        if dll_path is None:
+            msg = 'Could not find the Qmix SDK DLL %s.' % dll_filename
+            raise RuntimeError(msg)
         else:
-            self.dll_file = os.path.join(dll_dir, 'labbCAN_Pump_API.dll')
+            self.dll_path = dll_path
 
         self._ffi = FFI()
         self._ffi.cdef(PUMP_HEADER)
-        self._dll = self._ffi.dlopen(self.dll_file)
+        self._dll = self._ffi.dlopen(self.dll_path)
 
         self.index = index
         self._name = name

--- a/pyqmix/tools.py
+++ b/pyqmix/tools.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-
-from .error import QmixError
+import os
 
 
 def CHK(return_code, *args):
@@ -34,8 +33,66 @@ def CHK(return_code, *args):
     if return_code >= 0:
         return return_code
     else:
+        from .error import QmixError  # We import here to avoid circularity with error.py
         e = QmixError(return_code)
         error_string = e.error_string
         msg = (error_string + ", Error number: " + str(e.error_number) +
                ", Error code: " + str(e.error_code))
         raise RuntimeError(msg)
+
+
+def find_dll(dll_dir, dll_filename):
+    """
+    Try to find the specified DLL.
+
+    If a DLL directory was given, try to find the DLL there.
+
+    If no DLL directory was given, start looking for the DLL in the following
+    order:
+
+    - current working directory
+    - global DLL search paths (this also respects the PATH
+      environment variable)
+    - default Qmix SDK installation directory
+
+    Parameters
+    ----------
+    dll_dir : string or None
+        The directory containing the DLLs. Pass `None` to look in the default locations.
+    dll_filename : string
+        The name of the DLL to find, including filename extension.
+
+    Returns
+    -------
+    dll_path : string or None
+        The path of the DLL, or `None` if the DLL could not be found.
+
+    """
+    if not dll_dir:
+        if os.path.exists(dll_filename):  # Check current directory.
+            dll_path = dll_filename
+        else:
+            # Check DLL search paths.
+            import win32api
+            try:
+                win32api.LoadLibrary(dll_filename)
+                dll_path = dll_filename
+            except Exception:
+                # Check default installation directory.
+                import appdirs
+                dll_dir = appdirs.user_data_dir('QmixSDK', '')
+                if os.path.exists(os.path.join(dll_dir, dll_filename)):
+                    dll_path = os.path.join(dll_dir, dll_filename)
+                    # Add DLL dir to PATH, otherwise we won't be able to load the DLL.
+                    os.environ['PATH'] += os.pathsep + dll_dir
+                else:
+                    dll_path = None
+    else:
+        if os.path.exists(os.path.join(dll_dir, dll_filename)):
+            dll_path = os.path.join(dll_dir, dll_filename)
+            # Add DLL dir to PATH, otherwise we won't be able to load the DLL.
+            os.environ['PATH'] += os.pathsep + dll_dir
+        else:
+            dll_path = None
+
+    return dll_path

--- a/pyqmix/tools.py
+++ b/pyqmix/tools.py
@@ -69,30 +69,36 @@ def find_dll(dll_dir, dll_filename):
 
     """
     if not dll_dir:
-        if os.path.exists(dll_filename):  # Check current directory.
+        # Check current directory.
+        if os.path.exists(dll_filename):
             dll_path = dll_filename
-        else:
-            # Check DLL search paths.
-            import win32api
-            try:
-                win32api.LoadLibrary(dll_filename)
-                dll_path = dll_filename
-            except Exception:
-                # Check default installation directory.
-                import appdirs
-                dll_dir = appdirs.user_data_dir('QmixSDK', '')
-                if os.path.exists(os.path.join(dll_dir, dll_filename)):
-                    dll_path = os.path.join(dll_dir, dll_filename)
-                    # Add DLL dir to PATH, otherwise we won't be able to load the DLL.
-                    os.environ['PATH'] += os.pathsep + dll_dir
-                else:
-                    dll_path = None
+            return dll_path
+
+        # Check DLL search paths.
+        import win32api
+        try:
+            win32api.LoadLibrary(dll_filename)
+            dll_path = dll_filename
+            return dll_path
+        except Exception:
+            pass
+
+        # Check default installation directory.
+        import appdirs
+        dll_dir = appdirs.user_data_dir('QmixSDK', '')
+        if os.path.exists(os.path.join(dll_dir, dll_filename)):
+            dll_path = os.path.join(dll_dir, dll_filename)
+            # Add DLL dir to PATH, otherwise we won't be able to load the DLL.
+            os.environ['PATH'] += os.pathsep + dll_dir
+            return dll_path
+
+        return None
     else:
         if os.path.exists(os.path.join(dll_dir, dll_filename)):
             dll_path = os.path.join(dll_dir, dll_filename)
             # Add DLL dir to PATH, otherwise we won't be able to load the DLL.
             os.environ['PATH'] += os.pathsep + dll_dir
+            return dll_path
         else:
-            dll_path = None
+            return None
 
-    return dll_path

--- a/pyqmix/valve.py
+++ b/pyqmix/valve.py
@@ -11,7 +11,7 @@ if sys.version_info[0] < 3:
 
 from . import config
 from .dio import QmixDigitalIO
-from .tools import CHK
+from .tools import CHK, find_dll
 from .headers import VALVE_HEADER
 
 
@@ -43,14 +43,18 @@ class QmixValve(object):
             self.handle = handle
 
         dll_dir = config.read_config().get('qmix_dll_dir', None)
-        if dll_dir is None:
-            self.dll_file = 'labbCAN_Valve_API.dll'
+        dll_filename = 'labbCAN_Valve_API.dll'
+
+        dll_path = find_dll(dll_dir=dll_dir, dll_filename=dll_filename)
+        if dll_path is None:
+            msg = 'Could not find the Qmix SDK DLL %s.' % dll_filename
+            raise RuntimeError(msg)
         else:
-            self.dll_file = os.path.join(dll_dir, 'labbCAN_Valve_API.dll')
+            self.dll_path = dll_path
 
         self._ffi = FFI()
         self._ffi.cdef(VALVE_HEADER)
-        self._dll = self._ffi.dlopen(self.dll_file)
+        self._dll = self._ffi.dlopen(self.dll_path)
 
         if self.index is not None:
             self._handle = self._ffi.new('dev_hdl *', 0)


### PR DESCRIPTION
If a DLL directory was specified, try to find the DLL there.

If no DLL directory was given, start looking for the DLL in the following
order:
  - current working directory
  - global DLL search paths (this also respects the PATH
    environment variable)
  - default Qmix SDK installation directory

This closes #51 and should allow to address https://github.com/psyfood/pyqmix-web/issues/7.