### PR TITLE
Assume default location of Qmix configuration.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+2018-10-06
+----------
+* Assume default location of Qmix configuration files (to avoid full path).   
+
 2018-10-04
 ----------
 * Rename `switch_valve_when_finished` keyword argument to 

--- a/pyqmix/bus.py
+++ b/pyqmix/bus.py
@@ -56,8 +56,8 @@ class QmixBus(object):
         if config_dir is not None:
             self.config_dir = config_dir
         else:
-            msg = ('Please specify the Qmix configuration directory via '
-                   'pyqmix.config.set_qmix_config_dir() first.')
+            msg = ('Please specify the Qmix configuration via '
+                   'pyqmix.config.set_qmix_config() first.')
             raise RuntimeError(msg)
 
         self.auto_open = auto_open

--- a/pyqmix/config.py
+++ b/pyqmix/config.py
@@ -102,13 +102,24 @@ def set_qmix_config(config_name, configs_dir=None):
     ----------
     config_name : string
         The name of a Qmix configuration. Assumed to be stored at the default directory.
-    configs_dir : string
+    configs_dir : string or None
         The parent directory containing the Qmix configurations.
+        If ``None``, we will look for the Qmix configuration in the current
+        directory; if not found, move on to look in the Qmix default
+        directory.
+
+    Raises
+    ------
+    ValueError
+        If the specified configuration could not be found.
 
     """
 
     if configs_dir is None:
-        configs_dir = DEFAULT_CONFIGS_DIR
+        if os.path.exists(config_name):
+            configs_dir = os.path.abspath('.')
+        else:
+            configs_dir = DEFAULT_CONFIGS_DIR
 
     config_dir = os.path.join(configs_dir, config_name)
 

--- a/pyqmix/config.py
+++ b/pyqmix/config.py
@@ -13,6 +13,9 @@ yaml.default_flow_style = False
 PYQMIX_CONFIG_DIR = user_config_dir(appname='pyqmix', appauthor=False)
 PYQMIX_CONFIG_FILE = os.path.join(PYQMIX_CONFIG_DIR, 'config.yaml')
 
+DEFAULT_CONFIGS_DIR = os.path.normpath('C:/Users/Public/Documents/'
+                                      'QmixElements/Projects/default_project/'
+                                      'Configurations/')
 
 # Python 2 compatibility
 try:
@@ -63,18 +66,53 @@ def delete_config():
         pass
 
 
-def set_qmix_config_dir(d):
+def get_available_qmix_configs(configs_dir=None):
     """
-    Specify the location of the directory containing the Qmix configurations.
+    Create a list of available qmix configurations
 
     Parameters
     ----------
-    d : string
-        The Qmix configuration directory. Must be an absolute path.
+    configs_dir : string or None
+        The parent directory containing the Qmix configurations.
+        If ``None``, assume the default directory used by
+        Qmix Elements, i.e.,
+        `C:/Users/Public/Documents/QmixElements/Projects/default_project/Configurations/`.
+
+    Returns
+    -------
+    list of strings
+        Names of available Qmix configurations.
 
     """
+    if configs_dir is None:
+        configs_dir = DEFAULT_CONFIGS_DIR
+
+    def get_immediate_subdirectories(a_dir):
+        return [name for name in os.listdir(a_dir)
+                if os.path.isdir(os.path.join(a_dir, name))]
+
+    return get_immediate_subdirectories(configs_dir)
+
+
+def set_qmix_config(config_name, configs_dir=None):
+    """
+    Specify a Qmix configuration.
+
+    Parameters
+    ----------
+    config_name : string
+        The name of a Qmix configuration. Assumed to be stored at the default directory.
+    configs_dir : string
+        The parent directory containing the Qmix configurations.
+
+    """
+
+    if configs_dir is None:
+        configs_dir = DEFAULT_CONFIGS_DIR
+
+    config_dir = os.path.join(configs_dir, config_name)
     cfg = read_config()
-    cfg['qmix_config_dir'] = d
+    cfg['qmix_config_dir'] = config_dir
 
     with open(PYQMIX_CONFIG_FILE, 'w') as f:
         yaml.dump(cfg, f)
@@ -87,7 +125,7 @@ def set_qmix_dll_dir(d):
     Parameters
     ----------
     d : string
-        Th Qmix SDK DLL directory. Must be an absolute path.
+        The Qmix SDK DLL directory. Must be an absolute path.
 
     """
     cfg = read_config()

--- a/pyqmix/config.py
+++ b/pyqmix/config.py
@@ -111,6 +111,11 @@ def set_qmix_config(config_name, configs_dir=None):
         configs_dir = DEFAULT_CONFIGS_DIR
 
     config_dir = os.path.join(configs_dir, config_name)
+
+    if not os.path.exists(config_dir):
+        msg = 'The specified configuration does not exist: %s' % config_dir
+        raise ValueError(msg)
+
     cfg = read_config()
     cfg['qmix_config_dir'] = config_dir
 

--- a/pyqmix/config.py
+++ b/pyqmix/config.py
@@ -15,7 +15,7 @@ PYQMIX_CONFIG_FILE = os.path.join(PYQMIX_CONFIG_DIR, 'config.yaml')
 
 DEFAULT_CONFIGS_DIR = os.path.normpath('C:/Users/Public/Documents/'
                                       'QmixElements/Projects/default_project/'
-                                      'Configurations/')
+                                      'Configurations')
 
 # Python 2 compatibility
 try:

--- a/pyqmix/examples/simple.py
+++ b/pyqmix/examples/simple.py
@@ -11,10 +11,11 @@ import os.path as op
 import time
 
 # Location of Qmix device configuration and Qmix SDK DLLs.
-config_dir = op.abspath('./qmix_config')
+configs_dir = op.abspath('./')
+config_name = 'qmix_config'
 dll_dir = op.normpath('D:/QmixSDK')
 
-config.set_qmix_config_dir(config_dir)
+config.set_qmix_config(config_name=config_name, configs_dir=configs_dir)
 config.set_qmix_dll_dir(dll_dir)
 
 # Initialize the connection to the pump system.

--- a/pyqmix/examples/two_pumps.py
+++ b/pyqmix/examples/two_pumps.py
@@ -12,10 +12,11 @@ from time import sleep
 
 # Location of Qmix device configuration and Qmix SDK DLLs.
 # Adjust as needed.
-config_dir = op.abspath('./qmix_config')
+configs_dir = op.abspath('./')
+config_name = 'qmix_config'
 dll_dir = op.normpath('D:/QmixSDK')
 
-config.set_qmix_config_dir(config_dir)
+config.set_qmix_config(config_name=config_name, configs_dir=configs_dir)
 config.set_qmix_dll_dir(dll_dir)
 
 # Flow and volume units and dimensions of the syringes.


### PR DESCRIPTION
Suggestion on how to address issue #52.
The solution allows the user to specify a custom directory should the default one not be satisfactory. I am not sure whether this is necessary. 

Furthermore, I find it a bit unfortunate that the function 
``` python 
config.set_qmix_config_dir(n,p)
```
now needs different input than the 
```python 
config.set_qmix_dll_dir(d)
```
, but maybe this function (the dll one), is no longer in use? 

In any case, please have a look at it, and don't hesitate to alter the code.