### PR TITLE
BF: Avoid error when deleting configuration that is already empty

### DIFF
--- a/pyqmix/config.py
+++ b/pyqmix/config.py
@@ -60,7 +60,12 @@ def delete_config():
     Delete the configuration file.
 
     """
-    os.remove(PYQMIX_CONFIG_FILE)
+    # Try to remove config file. Avoid error if the file has already
+    # been deleted.
+    try:
+        os.remove(PYQMIX_CONFIG_FILE)
+    except OSError:
+        pass
 
     # Try to remove config directory. Only succeeds of directory
     # is empty.


### PR DESCRIPTION
Closes #61 by a try and except procedure. 
The code was tested on the CETONI pumps at DuPont, where it worked as intended; one could use the function:
``` python 
config.delete_config()
```  
repeatedly without producing error messages. 
