### PR TITLE
BF: Handle non-existent configuration path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Version 2019.1
+------------------
+* Handle non-existent configuration directory
+
 Version 2018.12.13
 ------------------
 * Update installation instructions

--- a/pyqmix/config.py
+++ b/pyqmix/config.py
@@ -92,6 +92,11 @@ def get_available_qmix_configs(configs_dir=None):
     list of strings
         Names of available Qmix configurations.
 
+    Raises
+    ------
+    ValueError
+        If the configuration directory does not exist.
+
     """
     if configs_dir is None:
         configs_dir = DEFAULT_CONFIGS_DIR
@@ -99,6 +104,10 @@ def get_available_qmix_configs(configs_dir=None):
     def get_immediate_subdirectories(a_dir):
         return [name for name in os.listdir(a_dir)
                 if os.path.isdir(os.path.join(a_dir, name))]
+
+    if not os.path.exists(configs_dir):
+        msg = 'The configuration directory does not exist: %s' % configs_dir
+        raise ValueError(msg)
 
     return get_immediate_subdirectories(configs_dir)
 


### PR DESCRIPTION
When checking for available pump configurations pyqmix assumes that their default location is: 
`C:/Users/Public/Documents/QmixElements/Projects/default_project/Configurations/`

If this directory does not exist pyqmix will now raise an error.

- [x] I have updated `CHANGES.md`
